### PR TITLE
Remove feed polling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: statusbot --poll-atom-feed $POLL_ATOM_FEED
+web: statusbot


### PR DESCRIPTION
Decided feed polling was too dangerous to do as a standard thing alongside web-hooks, as often old entries have disappeared from slack 🤔
