### PR TITLE
Add git to build-env image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:alpine AS build-env
 WORKDIR  /go/src/github.com/buildkite/statusbot
 ADD . .
+RUN apk add --update --no-cache git
 RUN go build -o statusbot
 
 # final stage


### PR DESCRIPTION
The build was failing. Probably because it worked last time it was deployed >1 year ago and the docker image isn't pinned. It's failing now for me so I've added git which was required by a go dependency when building. It's not present in the final image though, I don't believe its actually used though so it should be fine